### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ frameworks (namely Foundation.framework and Accelerate.framework).
 
 ### Importing/Using with CocoaPods
 
-Installation using Cocoapods is no longer the recommended way for using YCMatrix, but it is still a perfectly viable option.
+Installation using CocoaPods is no longer the recommended way for using YCMatrix, but it is still a perfectly viable option.
 There is an [official guide to using CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html). 
 YCMatrix may be easily added as a project dependency by following 
 the guide.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
